### PR TITLE
Feature/reneame cmd vel

### DIFF
--- a/include/keybrd_teleop/teleop_key.h
+++ b/include/keybrd_teleop/teleop_key.h
@@ -9,7 +9,7 @@
 class TeleopKeybrd
 {
 public:
-    TeleopKeybrd(const ros::NodeHandle& nh, std::string robot, std::string command, std::string velocity );
+    TeleopKeybrd(const ros::NodeHandle& nh, std::string robot, std::string cmd_vel);
     void keyLoop();
 
 protected:

--- a/src/keybrd_teleop/src/teleop_key.cpp
+++ b/src/keybrd_teleop/src/teleop_key.cpp
@@ -6,7 +6,7 @@
 
 using namespace std;
 
-TeleopKeybrd::TeleopKeybrd(const ros::NodeHandle& nh, std::string robot, std::string command, std::string velocity ):
+TeleopKeybrd::TeleopKeybrd(const ros::NodeHandle& nh, std::string robot, std::string cmd_vel ):
 mLinear(0.0),
 mAngular(0.0),
 mMaxLin(1.5),
@@ -19,7 +19,7 @@ mLocked(false)
 {
 	mVelPub = m_nh.advertise<geometry_msgs::Twist>("/cmd_vel", 10);
 
-    mPubVelControl = m_nh.advertise<geometry_msgs::Twist>("/" + robot + "/" + command + "/" + velocity, 10);
+    mPubVelControl = m_nh.advertise<geometry_msgs::Twist>("/" + robot + "/" + cmd_vel, 10);
 
 	// >>>>> Parameters
 	string nodeName = ros::this_node::getName();

--- a/src/keybrd_teleop_node.cpp
+++ b/src/keybrd_teleop_node.cpp
@@ -2,8 +2,7 @@
 #include "std_msgs/String.h"
 
 std::string serial_bridge_string = "robot";
-std::string command = "command";
-std::string velocity = "velocity";
+std::string cmd_vel_string = "cmd_vel";
 
 std::string name_node = "keyboard_drive_bridge";
 
@@ -26,19 +25,12 @@ int main(int argc, char** argv)
 			nh.setParam(name_node + "/serial_bridge", serial_bridge_string);
 	}
 
-	if (nh.hasParam(name_node + "/command")) {
-			nh.getParam(name_node + "/command", command);
+    if (nh.hasParam(name_node + "/cmd_vel")) {
+            nh.getParam(name_node + "/cmd_vel", cmd_vel_string);
 	} else {
-			nh.setParam(name_node + "/command", command);
-	}
-
-	if (nh.hasParam(name_node + "/velocity")) {
-			nh.getParam(name_node + "/velocity", velocity);
-	} else {
-			nh.setParam(name_node + "/velocity", velocity);
-	}
-
-    TeleopKeybrd teleop(nh, serial_bridge_string, command, velocity );
+            nh.setParam(name_node + "/cmd_vel", cmd_vel_string);
+    }
+    TeleopKeybrd teleop(nh, serial_bridge_string, cmd_vel_string );
 
 	teleop.keyLoop();
 

--- a/src/keybrd_teleop_node.cpp
+++ b/src/keybrd_teleop_node.cpp
@@ -1,7 +1,7 @@
 #include <keybrd_teleop/teleop_key.h>
 #include "std_msgs/String.h"
 
-std::string serial_bridge_string = "robot";
+std::string robot_name_string = "robot";
 std::string cmd_vel_string = "cmd_vel";
 
 std::string name_node = "keyboard_drive_bridge";
@@ -14,23 +14,17 @@ int main(int argc, char** argv)
 	//Load configuration
 
     if (nh.hasParam("/info/robot_name")) {
-        nh.getParam("/info/robot_name", serial_bridge_string);
+        nh.getParam("/info/robot_name", robot_name_string);
     } else {
-        nh.setParam("/info/robot_name", serial_bridge_string);
+        nh.setParam("/info/robot_name", robot_name_string);
     }
-
-	if (nh.hasParam(name_node + "/serial_bridge")) {
-			nh.getParam(name_node + "/serial_bridge", serial_bridge_string);
-	} else {
-			nh.setParam(name_node + "/serial_bridge", serial_bridge_string);
-	}
 
     if (nh.hasParam(name_node + "/cmd_vel")) {
             nh.getParam(name_node + "/cmd_vel", cmd_vel_string);
 	} else {
             nh.setParam(name_node + "/cmd_vel", cmd_vel_string);
     }
-    TeleopKeybrd teleop(nh, serial_bridge_string, cmd_vel_string );
+    TeleopKeybrd teleop(nh, robot_name_string, cmd_vel_string );
 
 	teleop.keyLoop();
 


### PR DESCRIPTION
In according with: https://github.com/officinerobotiche/ros_serial_bridge/issues/18

renamed node to drive and removed a futile param **serial_bridge**

``` diff
     if (nh.hasParam("/info/robot_name")) {
-        nh.getParam("/info/robot_name", serial_bridge_string);
+        nh.getParam("/info/robot_name", robot_name_string);
     } else {
-        nh.setParam("/info/robot_name", serial_bridge_string);
+        nh.setParam("/info/robot_name", robot_name_string);
     }

-   if (nh.hasParam(name_node + "/serial_bridge")) {
-           nh.getParam(name_node + "/serial_bridge", serial_bridge_string);
+    if (nh.hasParam(name_node + "/cmd_vel")) {
+            nh.getParam(name_node + "/cmd_vel", cmd_vel_string);
    } else {
-           nh.setParam(name_node + "/serial_bridge", serial_bridge_string);
-   }
```
